### PR TITLE
Fixing extra card -sometimes- swiped

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
-        classpath 'com.novoda:bintray-release:0.3.4'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.novoda:bintray-release:0.8.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Tue Jan 23 09:50:54 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/library/src/main/java/link/fls/swipestack/SwipeHelper.java
+++ b/library/src/main/java/link/fls/swipestack/SwipeHelper.java
@@ -19,6 +19,7 @@ package link.fls.swipestack;
 import android.animation.Animator;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewPropertyAnimator;
 import android.view.animation.OvershootInterpolator;
 
 import link.fls.swipestack.util.AnimationUtils;
@@ -138,15 +139,16 @@ public class SwipeHelper implements View.OnTouchListener {
     private void swipeViewToLeft(int duration) {
         if (!mListenForTouchEvents) return;
         mListenForTouchEvents = false;
-        mObservedView.animate().cancel();
-        mObservedView.animate()
-                .x(-mSwipeStack.getWidth() + mObservedView.getX())
+        final ViewPropertyAnimator animator = mObservedView.animate();
+        animator.cancel();
+        animator.x(-mSwipeStack.getWidth() + mObservedView.getX())
                 .rotation(-mRotateDegrees)
                 .alpha(0f)
                 .setDuration(duration)
                 .setListener(new AnimationUtils.AnimationEndListener() {
                     @Override
                     public void onAnimationEnd(Animator animation) {
+                        animator.setListener(null);
                         mSwipeStack.onViewSwipedToLeft();
                     }
                 });
@@ -155,15 +157,16 @@ public class SwipeHelper implements View.OnTouchListener {
     private void swipeViewToRight(int duration) {
         if (!mListenForTouchEvents) return;
         mListenForTouchEvents = false;
-        mObservedView.animate().cancel();
-        mObservedView.animate()
-                .x(mSwipeStack.getWidth() + mObservedView.getX())
+        final ViewPropertyAnimator animator = mObservedView.animate();
+        animator.cancel();
+        animator.x(mSwipeStack.getWidth() + mObservedView.getX())
                 .rotation(mRotateDegrees)
                 .alpha(0f)
                 .setDuration(duration)
                 .setListener(new AnimationUtils.AnimationEndListener() {
                     @Override
                     public void onAnimationEnd(Animator animation) {
+                        animator.setListener(null);
                         mSwipeStack.onViewSwipedToRight();
                     }
                 });


### PR DESCRIPTION
Fixes #26 
- Updated Gradle to work with Android Studio 3.0
- Clearing animation listener when swiped view settles left or right after the animation ends, it was getting an extra call as end of another animation for the same view, which was causing an extra card (top one) to be removed when swiping quickly